### PR TITLE
Refactor: "MethodArgumentNotValidException 발생시, ErrorResponse에 2개 이상의…

### DIFF
--- a/src/main/java/umc/liview/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/umc/liview/exception/advice/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import umc.liview.exception.ErrorResponse;
 import umc.liview.exception.code.ErrorCode;
 
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
@@ -82,7 +83,8 @@ public class GlobalExceptionHandler {
         ResponseEntity<ErrorResponse> response;
         if (e.getClass().equals(MethodArgumentNotValidException.class)) {
             response = ErrorResponse.toResponseEntity(ErrorCode.INVALID_REQUEST_PARAMETER,
-                    Objects.requireNonNull(((MethodArgumentNotValidException) e).getBindingResult().getFieldError()).getDefaultMessage());
+                    ((MethodArgumentNotValidException) e).getBindingResult().getFieldErrors().stream()
+                            .map(err -> err.getDefaultMessage()).collect(Collectors.joining(" and ")));
         } else {
             response = ErrorResponse.toResponseEntity(errorCode);
         }


### PR DESCRIPTION
… 예외 메세지 담을 수 있게 리팩토링 "

기존의 여러 요인으로 유효성 검사 실패했을 시, 하나의 원인만 나왔던 오류를 수정

Resolves: #40